### PR TITLE
Change sh to bash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ impl<'a> DMenu<'a> {
             map.insert(key, item);
         }
 
-        let shell_output = Command::new("sh")
+        let shell_output = Command::new("bash")
             .args(&[
                 "-c",
                 &format!("echo -e '{}' | {}", list_string, self.to_command()),


### PR DESCRIPTION
Thanks for the great crate! 
Although I have come across one slight problem in my testing.

On Debian, `sh` doesn't support echo's `-e` flag so the first item in the menu is always prefixed with `-e`. Changing the shell used to bash fixes this.